### PR TITLE
accept additional parameters passed to kubectl get node

### DIFF
--- a/pull-allnodes/Dockerfile
+++ b/pull-allnodes/Dockerfile
@@ -4,7 +4,7 @@ RUN apk add --no-cache jq
 
 WORKDIR /tmp
 
-ADD https://storage.googleapis.com/kubernetes-release/release/v1.5.4/bin/linux/amd64/kubectl /usr/local/bin/kubectl
+ADD https://storage.googleapis.com/kubernetes-release/release/v1.7.2/bin/linux/amd64/kubectl /usr/local/bin/kubectl
 
 ADD pulljob.yaml pulljob.yaml
 ADD allnodes.sh /usr/local/bin/allnodes.sh

--- a/pull-allnodes/pulljob.yaml
+++ b/pull-allnodes/pulljob.yaml
@@ -15,6 +15,17 @@ spec:
       annotations:
         scheduler.alpha.kubernetes.io/affinity: >
           {
+            "nodeAffinity": {
+              "requiredDuringSchedulingIgnoredDuringExecution": {
+                "nodeSelectorTerms": [{
+                  "matchExpressions": [{
+                    "key": "kubernetes.io/hostname",
+                    "operator": "In",
+                    "values": {NODENAMES}
+                  }]
+                }]
+              }
+            },
             "podAntiAffinity": {
               "requiredDuringSchedulingIgnoredDuringExecution": [{
                  "topologyKey": "kubernetes.io/hostname",

--- a/pull-allnodes/pulljob.yaml
+++ b/pull-allnodes/pulljob.yaml
@@ -11,30 +11,7 @@ spec:
   template:
     metadata:
       labels:
-        yuvi.in/pod-puller: "true"             
-      annotations:
-        scheduler.alpha.kubernetes.io/affinity: >
-          {
-            "nodeAffinity": {
-              "requiredDuringSchedulingIgnoredDuringExecution": {
-                "nodeSelectorTerms": [{
-                  "matchExpressions": [{
-                    "key": "kubernetes.io/hostname",
-                    "operator": "In",
-                    "values": {NODENAMES}
-                  }]
-                }]
-              }
-            },
-            "podAntiAffinity": {
-              "requiredDuringSchedulingIgnoredDuringExecution": [{
-                 "topologyKey": "kubernetes.io/hostname",
-                 "labelSelector": {
-                   "matchLabels": { "yuvi.in/pod-puller": "true"}
-                 }
-              }]
-            }
-          }
+        yuvi.in/pod-puller: "true"
     spec:
       restartPolicy: Never
       containers:
@@ -48,3 +25,19 @@ spec:
         - name: docker-socket
           hostPath:
             path: /var/run/docker.sock
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: "kubernetes.io/hostname"
+                operator: In
+                values: {NODENAMES}
+        podAntiAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+          - topologyKey: "kubernetes.io/hostname"
+            labelSelector:
+              matchLabels:
+                "yuvi.in/pod-puller": "true"
+      tolerations:
+        - operator: Exists


### PR DESCRIPTION
We use a dedicated node pool for single-user notebook server, so we want the image-puller only runs in nodes in this pool. with this pr, it just need pass "-l", "cloud.google.com/gke-nodepool=notebook-pool"