### PR TITLE
Set IMAGESHORTNAME to something valid

### DIFF
--- a/pull-allnodes/allnodes.sh
+++ b/pull-allnodes/allnodes.sh
@@ -5,7 +5,7 @@ IMAGE="${1}"
 TAG="${2}"
 NODECOUNT=$(kubectl get node | awk '{ if ($2 == "Ready") print $1; }'  | wc -l)
 
-IMAGESHORTNAME=$(echo -n ${IMAGE} | cut -d'/' -f3)
+IMAGESHORTNAME=$(basename ${IMAGE})
 JOBNAME=$(echo -n "pull-${IMAGESHORTNAME}-${TAG}-$(date +'%s')" | sed 's/\./-/g')
 
 echo "Pulling ${IMAGE}:${TAG} on ${NODECOUNT} nodes" 


### PR DESCRIPTION
Passing a two-element docker image (e.g. foo/bar) to cut -d/ -f3 will return an empty string, while basename should always return the last element.